### PR TITLE
fixed color of past event heading, faq heading and header-wave for da…

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
                 preserveAspectRatio="none">
                 <path
                     d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
-                    class="shape-fill"></path>
+                    class="shape-fill" id="h-wave"></path>
             </svg>
         </div>
     </div>
@@ -188,7 +188,7 @@
 
 
     <div class="past-events" id="pastevents">
-        <h1 class="events-title container-fluid">Our Past Events</h1>
+        <h1 class="events-title container-fluid" id="p-heading">Our Past Events</h1>
         <div class="overlay-image">
             <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
                 <div class="carousel-slide">
@@ -327,7 +327,7 @@
 
 
     <!---FAQ section goes here-->
-    <h1 class="faq-heading">Frequently Asked Questions</h1>
+    <h1 class="faq-heading" id="f-heading">Frequently Asked Questions</h1>
     <div class="faq-container">
         <div class="faq" id="faq1" onclick="show1()">
             <div>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
 function darkMode(){
     document.body.classList.toggle("dark");
+    // Added if/else condiditon to change the color of past event heading, faq heading and header wave 
+    if((document.getElementById("p-heading").style.color==="white") && (document.getElementById("f-heading").style.color==="white") || (document.getElementById("h-wave").style.fill==="#292c35")){
+        document.getElementById("p-heading").style.color="black";
+        document.getElementById("f-heading").style.color="black";
+        document.getElementById("h-wave").style.fill="#ffffff";
+    }
+    else{
+        document.getElementById("p-heading").style.color="white";
+        document.getElementById("f-heading").style.color="white";
+        document.getElementById("h-wave").style.fill="#292c35";
+    }
 }
 const toggles = document.querySelectorAll('.faq-toggle');
 


### PR DESCRIPTION
### Related Issue
- Heading of past events and FAQ section is not clearly visible after enabling dark mode. #100

### Proposed Changes
- Fixed color for past event and faq heading when dark mode is on.
- Fixed header wave color when dark mode is on.

### Checklist
- [x] Documentation of the code
- [x] Add your name to the CONTRIBUTORS file 
- [x] Testing your code in the local machine 

### Screenshots
![P2](https://user-images.githubusercontent.com/102366326/194293410-726f31a1-c100-40cc-bcf1-735b47fbd14f.jpg)
![P3](https://user-images.githubusercontent.com/102366326/194293419-3575fca5-f0a2-4466-b3b4-bbf1046cf9fa.jpg)

