### PR TITLE
Fix notif-bar cross, revamp accomplishment section

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,11 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
         integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
         crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js"
+     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js"
         integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+"
         crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/jquery-3.6.1.min.js"
-        integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
+        integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script> 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GirlScript Asansol</title>
     <link rel="icon" type="image/x-icon" href="/Assets/asn-logo-modified.png">
@@ -104,7 +104,7 @@
                 <a href="https://discord.gg/vYSspBkgNc"><button class="button-61" role="button">Join Discord</button></a>
                 <!--Material UI button added-->
             </div>
-            <div style="position:fixed; right: 30px">
+            <div style="position:absolute; right: 30px">
                 <i class="fa fa-remove" style="cursor: pointer;font-size: 1.3rem;" onclick="handleClose()"></i>
             </div>
 
@@ -477,7 +477,7 @@
 
 
         </div>
-
+         <div class="debu"></div>
 
         <!---Achievements section goes here-->
         <section class="achievement-section">
@@ -492,7 +492,7 @@
                 <div class="achievement-container">
                     <i class="fas fa-calendar-check achi-icon"></i>
                     <span class="num" data-val="340">25+</span>
-                    <span class="text">Events</span>
+                    <span class="text">Events Organized</span>
                 </div>
                 <div class="achievement-container">
                     <i class="fas fa-pen achi-icon"></i>
@@ -502,6 +502,7 @@
             </div>
         </section>
 
+<div class="debu"></div>
 
         <!---Our team section goes here-->
 
@@ -584,7 +585,7 @@
             </div>
         </section>
 
-
+        <div class="debu"></div>
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -606,7 +606,7 @@ span.text {
 
   }
   .achievement-section h1{
-    padding-bottom: 10px;
+    padding-bottom: 25px;
   }
   .achi-icon{
     /* width: fit-content; */

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,14 @@
 html {
   scroll-behavior: smooth;
 }
+.debu{
+      width: 50%;
+      height: 8px;
+      margin: 10px auto;
+      border-radius: 100px;
+      background-image:linear-gradient(270deg, rgb(252, 115, 60), rgb(252, 176, 76)) ;
+}
+
 
 body {
   transition: background 0.2s linear;
@@ -513,12 +521,15 @@ body.dark {
 
 /* Achievements section styles goes here */
 .achievement-section{
-  margin: 100px 0;
+  margin: 0px 0;
+  /* padding-bottom: 10px; */
+  /* height: 500px; */
 }
 .achievement-section h1 {
   text-align: center;
   position: relative;
   font-family: "Lato", sans-serif;
+ 
 }
 .achievement-wrapper {
   position: relative;
@@ -576,17 +587,46 @@ span.text {
 }
 @media screen and (max-width: 768px) {
   .achievement-wrapper {
-    margin-top: 190px;
+    margin-top: -55px;
+    /* padding: 200px 11px 0px 30px  ; */
     width: 90vw;
     flex-wrap: wrap;
     gap: 30px;
   }
   .achievement-container {
     width: calc(50% - 40px);
-    height: 30vmin;
-    font-size: 14px;
+    height: 20vmin;
+    font-size: 10px;
+    padding: 0.5em 0;
+  }
+  .achievement-section{
+    margin: 0px 0;
+    padding-bottom: 10px;
+    height: 450px;
+
+  }
+  .achievement-section h1{
+    padding-bottom: 10px;
+  }
+  .achi-icon{
+    /* width: fit-content; */
+    width: 60px;
+    /* height: 60px; */
+    margin-top: 25px;
+    font-size: 5em;
+
+  } 
+  .num{
+    width: 60px;
+    padding-left: 155px;
+    position: absolute;
+  }
+  .text{
+    padding-left: 140px;
+    padding-bottom: 20px;
   }
 }
+
 @media screen and (max-width: 480px) {
   .achievement-section h1 {
     font-size: 3em;
@@ -595,10 +635,11 @@ span.text {
     gap: 15px;
   }
   .achievement-container {
-    width: 80%;
+    width: 70%;
     height: 25vmin;
     font-size: 8px;
   }
+  
 }
 
 /*  Our Team section Styles goes here */


### PR DESCRIPTION
### Related Issue
- Issue number goes here: #129 

### Proposed Changes <!-- Add the changes that you have made -->
- removed noti bar has a cross button which overlays in the website.
- Added a gradient line (small) after the past event section, accomplishment and faq
- Decreased the padding (in the mobile view) between the accomplishment section and faq section
- Added some padding at the bottom of the h1 of the accomplishment(mobile view).

### Screenshots
  accomplishment section

![Screenshot (3)](https://user-images.githubusercontent.com/92798917/194644745-b0b0de4d-7e0a-4c67-977d-2b842deadcb3.png)

removed cross bar
![Screenshot (4)](https://user-images.githubusercontent.com/92798917/194644789-29a7bca2-b3f0-42b6-9dd9-f125b1821489.png)
