### PR TITLE
Fix FAQ Picture overflowing and not centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,7 +618,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-16 text-center">
+                    <div class="col-md-6 d-flex justify-content-center align-items-start">
                         <img src="./Assets/faq-illustration.svg" id="faq-illlustration" alt="faq">
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -719,9 +719,8 @@ span.text {
 }
 
 #faq-illlustration {
-  width: 430px;
-  margin-top: 15px;
-  margin-left: 9rem;
+  width: 100%;
+  align-items: center;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
### Related Issue
- Issue number goes here: #166 

### Proposed Changes <!-- Add the changes that you have made -->
- Made the FAQ illustration container flex and applied align-items / justify-content for it to center
- Changed width to 100% on bigger screens

### Checklist <!-- Add [x] to the boxes-[] to check on it -->
- [x] Documentation of the code <!-- Add relevant comments for better readability -->
- [x] Add your name to the CONTRIBUTORS file 
- [x] Testing your code in the local machine 

### Screenshots
 <!-- Add relevant screenshots so that the maintainers can understand the code -->

### Before
![image](https://user-images.githubusercontent.com/86471530/194747741-624397f2-7c11-49dc-b405-bf3b80c7df1a.png)
![image](https://user-images.githubusercontent.com/86471530/194747760-faef55bb-6318-4249-a913-4698e3809665.png)
![image](https://user-images.githubusercontent.com/86471530/194747747-d72859d1-6f6d-4066-85dc-13a811ae5186.png)

### After
![image](https://user-images.githubusercontent.com/86471530/194747768-fee42054-e3fc-47ba-9e84-ea5d6c80fde1.png)
![image](https://user-images.githubusercontent.com/86471530/194747772-3a10306c-54f3-4e4e-aefa-117b7eda398a.png)


